### PR TITLE
Bugfix of the allowed risk recomputation

### DIFF
--- a/PaperSandbox/src/main/java/vahy/ralph/policy/RiskAverseSearchTree.java
+++ b/PaperSandbox/src/main/java/vahy/ralph/policy/RiskAverseSearchTree.java
@@ -190,7 +190,7 @@ public class RiskAverseSearchTree<
                 totalRiskAllowed = (totalRiskAllowed - cumulativeNominator) / cumulativeDenominator;
                 totalRiskAllowed = roundRiskIfBelowZero(totalRiskAllowed, "TotalRiskAllowed");
                 var riskDiff = totalRiskAllowed - initialRiskAllowed;
-                totalRiskAllowed = riskDiff > 0 ? initialRiskAllowed + riskDiff * riskDecay: initialRiskAllowed - riskDiff * riskDecay;
+                totalRiskAllowed = riskDiff < 0 ? initialRiskAllowed + riskDiff * riskDecay: initialRiskAllowed - riskDiff * riskDecay;
             }
         }
         if(TRACE_ENABLED) {


### PR DESCRIPTION
Assume that the initial allowed risk is `totalRiskAllowed == 0.6`. The agent then performs a risky action that updates the `totalRiskAllowed` to `0.4`. Then `riskDiff = 0.4 - 0.6 = -0.2`. With the default `riskDecay == 1`, the new `totalRiskAllowed` is then equal to `0.6 - (-0.2) == 0.8`, because the incorrect branch of the ternary operator has been chosen.