### PR TITLE
Bugfix of the bugfix of the risk recomputation

### DIFF
--- a/PaperSandbox/src/main/java/vahy/ralph/policy/RiskAverseSearchTree.java
+++ b/PaperSandbox/src/main/java/vahy/ralph/policy/RiskAverseSearchTree.java
@@ -190,7 +190,7 @@ public class RiskAverseSearchTree<
                 totalRiskAllowed = (totalRiskAllowed - cumulativeNominator) / cumulativeDenominator;
                 totalRiskAllowed = roundRiskIfBelowZero(totalRiskAllowed, "TotalRiskAllowed");
                 var riskDiff = totalRiskAllowed - initialRiskAllowed;
-                totalRiskAllowed = riskDiff < 0 ? initialRiskAllowed + riskDiff * riskDecay: initialRiskAllowed - riskDiff * riskDecay;
+                totalRiskAllowed = initialRiskAllowed + riskDiff * riskDecay;
             }
         }
         if(TRACE_ENABLED) {


### PR DESCRIPTION
Ok, this is awkward. I was so focused on fixing the negative `riskDiff` branch that I have missed the positive `riskDiff` branch. The correct formula is simply:
`totalRiskAllowed = initialRiskAllowed + riskDiff * riskDecay`
because with `riskDecay == 1`:
`totalRiskAllowed == initialRiskAllowed + (totalRiskAllowed - initialRiskAllowed)` which is simply:
`totalRiskAllowed == totalRiskAllowed` as it should be